### PR TITLE
feat: go-fvm-sdk-tool  go v1.18 supporting

### DIFF
--- a/tools/sdk_tool/src/utils.rs
+++ b/tools/sdk_tool/src/utils.rs
@@ -45,15 +45,13 @@ pub fn check_go_install() -> Result<bool> {
         Ok(child) => {
             let output = child.wait_with_output()?;
             let version_str = String::from_utf8(output.stdout)?;
-            if version_str.contains("go1.16.") || version_str.contains("go1.17.") {
-                Ok(true)
-            } else {
-                Err(anyhow!(
-                    "uncorect go version must be go 1.16.x/go1.17.x but got {}",
-                    version_str
-                ))
+            for s in SUPPORT_GO_VERSIONS.iter() {
+                if version_str.contains(s) {
+                    return Ok(true);
+                }
             }
-        }
+            Err(anyhow!("incorrect go version:{},must in {:?}", version_str, SUPPORT_GO_VERSIONS))
+        },
         Err(e) => {
             if let ErrorKind::NotFound = e.kind() {
                 Err(anyhow!("unable to found go-fvm-sdk-tools(fvm), please install this tool in https://go.dev/dl"))
@@ -63,3 +61,5 @@ pub fn check_go_install() -> Result<bool> {
         }
     }
 }
+
+const SUPPORT_GO_VERSIONS: &'static [&'static str] = &["go1.16.", "go1.17.", "go1.18."];

--- a/tools/sdk_tool/src/utils.rs
+++ b/tools/sdk_tool/src/utils.rs
@@ -50,8 +50,12 @@ pub fn check_go_install() -> Result<bool> {
                     return Ok(true);
                 }
             }
-            Err(anyhow!("incorrect go version:{},must in {:?}", version_str, SUPPORT_GO_VERSIONS))
-        },
+            Err(anyhow!(
+                "incorrect go version:{},must in {:?}",
+                version_str,
+                SUPPORT_GO_VERSIONS
+            ))
+        }
         Err(e) => {
             if let ErrorKind::NotFound = e.kind() {
                 Err(anyhow!("unable to found go-fvm-sdk-tools(fvm), please install this tool in https://go.dev/dl"))
@@ -62,4 +66,4 @@ pub fn check_go_install() -> Result<bool> {
     }
 }
 
-const SUPPORT_GO_VERSIONS: &'static [&'static str] = &["go1.16.", "go1.17.", "go1.18."];
+const SUPPORT_GO_VERSIONS: &[&str] = &["go1.16.", "go1.17.", "go1.18."];


### PR DESCRIPTION
go-fvm-sdk-tool  go v1.18 supporting.
fixes #40 